### PR TITLE
Use acm-hive-openshift-releases backplane-2.3 branch

### DIFF
--- a/pkg/controller/gitrepo.go
+++ b/pkg/controller/gitrepo.go
@@ -42,7 +42,7 @@ const (
 
 	// Default values
 	DefaultGitRepoUrl    = "https://github.com/stolostron/acm-hive-openshift-releases.git"
-	DefaultGitRepoBranch = "backplane-2.2"
+	DefaultGitRepoBranch = "backplane-2.3"
 	DefaultGitRepoPath   = "clusterImageSets"
 	DefaultChannel       = "fast"
 )


### PR DESCRIPTION
Use clusterimagesets in the backplane-2.3 branch of the acm-hive-openshift-releases repo

https://issues.redhat.com/browse/ACM-3945