### PR TITLE
Add leader election settings

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,10 +1,10 @@
 sonar.projectKey=open-cluster-management_cluster-image-set-controller
 sonar.projectName=cluster-imageset-controller
 sonar.sources=.
-sonar.exclusions=**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**
+sonar.exclusions=**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**,**/cmd/**
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
-sonar.test.exclusions=**/*_generated*.go,**/*_generated/**,**/vendor/**,**/test/**
+sonar.test.exclusions=**/*_generated*.go,**/*_generated/**,**/vendor/**,**/test/**,**/cmd/**
 sonar.go.tests.reportPaths=report.json
 sonar.go.coverage.reportPaths=coverage.out
 sonar.externalIssuesReportPaths=gosec.json


### PR DESCRIPTION
This PR adds the leader election settings with default values:
``` 
--leader-election-lease-duration=136s
--leader-election-renew-deadline=107s
--leader-election-retry-period=26s
```

Updates sonar properties to ignore the controllers `main.go`