### PR TITLE
ACM-15094: Update default clusterimagesets to supported OCP versions where n=4.18

### DIFF
--- a/pkg/controller/gitrepo.go
+++ b/pkg/controller/gitrepo.go
@@ -42,7 +42,7 @@ const (
 
 	// Default values
 	DefaultGitRepoUrl    = "https://github.com/stolostron/acm-hive-openshift-releases.git"
-	DefaultGitRepoBranch = "backplane-2.6"
+	DefaultGitRepoBranch = "backplane-2.8"
 	DefaultGitRepoPath   = "clusterImageSets"
 	DefaultChannel       = "fast"
 )


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-15094