### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for cluster-image-set-controller-mce-29

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -11,8 +11,9 @@ RUN make build-konflux --warn-undefined-variables
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
-    name="cluster-image-set-controller" \
+    name="multicluster-engine/cluster-image-set-controller-rhel9" \
     com.redhat.component="cluster-image-set-controller" \
+    cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
     description="Cluster image set controller" \
     maintainer="acm-contact@redhat.com" \
     io.k8s.description="Cluster image set controller" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
