### PR TITLE
Add repository url label to container images

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -11,6 +11,7 @@ RUN make build-konflux --warn-undefined-variables
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
+      url="https://github.com/stolostron/cluster-image-set-controller" \
     name="cluster-image-set-controller" \
     com.redhat.component="cluster-image-set-controller" \
     description="Cluster image set controller" \


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** backplane-2.10

**Components affected:** cluster-image-set-controller

**Branch details:** cluster-image-set-controller (branch: backplane-2.10)

**Label added:**
- url: https://github.com/stolostron/cluster-image-set-controller

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.