### PR TITLE
update default branch version for mce 2.11

### DIFF
--- a/pkg/controller/gitrepo.go
+++ b/pkg/controller/gitrepo.go
@@ -42,7 +42,7 @@ const (
 
 	// Default values
 	DefaultGitRepoUrl    = "https://github.com/stolostron/acm-hive-openshift-releases.git"
-	DefaultGitRepoBranch = "backplane-2.10"
+	DefaultGitRepoBranch = "backplane-2.11"
 	DefaultGitRepoPath   = "clusterImageSets"
 	DefaultChannel       = "fast"
 )


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-28947

Update the branch version of which we get the default imagesets for MCE 2.11

In the future, we can consider having this value set to the branch name automatically, and when we create a new branch it can set this value right away.