### PR TITLE
Add FIPS build flags to Dockerfile

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -4,7 +4,7 @@ COPY . .
 ENV GO_PACKAGE github.com/stolostron/cluster-imageset-controller
 
 # Build
-RUN make build-konflux --warn-undefined-variables
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime make build-konflux --warn-undefined-variables
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
## Summary
- Add `CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime` to `make build-konflux` command in `Dockerfile.rhtap` for FIPS compliance

JIRA: HYPBLD-844

Made with [Cursor](https://cursor.com)